### PR TITLE
test packages + tox.ini

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ requires = [
 test_requires = [
     'codecov',
     'flake8',
+    'pytest',
     'pytest-cov',
     'pytest-helpers-namespace',
     'pytest-mock',
@@ -36,6 +37,7 @@ setup(
     url='https://github.com/thiagofigueiro/nexus3-cli',
     long_description=readme,
     long_description_content_type="text/markdown",
+    setup_requires=["pytest-runner"],
     install_requires=requires,
     tests_require=test_requires,
     license='MIT',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py36, py37
+
+[testenv]
+commands = python setup.py test


### PR DESCRIPTION
Hi Thiago,

When running the tests on a clean environment we had failure. According to:

https://docs.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner

we should add pytest and pytest-runner to setup.py. Also added a `tox.ini` file to help the testing.