### PR TITLE
use fake.pystr in tests to create more random names

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,7 +197,7 @@ def find_file_count(dir_name):
 
 @pytest.fixture
 def hosted_raw_repo_empty(tmpdir, faker):
-    repo_name = faker.word()
+    repo_name = faker.pystr()
     command = 'nexus3 repo create hosted raw {}'.format(repo_name)
     check_call(command.split())
     return repo_name

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -125,7 +125,7 @@ def test_download_tree(
     different formats.
     """
     src_dir, x_file_set = deep_file_tree
-    repo = faker.word()
+    repo = faker.pystr()
     dst_dir = faker.uri_path() + '/'
     path = dst_dir[:-1] + src_dir
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -137,7 +137,7 @@ def test_upload_tree(nexus_client, deep_file_tree, faker):
     resulting list of files in nexus corresponds to the uploaded list of files.
     """
     src_dir, x_file_set = deep_file_tree
-    repo = faker.word()
+    repo = faker.pystr()
     dst_dir = faker.uri_path() + '/'
     path = dst_dir[:-1] + src_dir
 


### PR DESCRIPTION
Fix issue where some tests fail if a repository is attempted to be created and another repository by same name already exists. 