### PR TITLE
Repository configuration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import io
 from setuptools import find_packages, setup
 
 package_name = 'nexus3-cli'
-package_version = '2.0.3'
+package_version = '2.1.0'
 
 requires = [
     'clint',

--- a/src/nexuscli/api/repository/collection.py
+++ b/src/nexuscli/api/repository/collection.py
@@ -5,53 +5,139 @@ from nexuscli.api.repository import model
 
 SCRIPT_NAME_CREATE = 'nexus3-cli-repository-create'
 SCRIPT_NAME_DELETE = 'nexus3-cli-repository-delete'
+SCRIPT_NAME_GET = 'nexus3-cli-repository-get'
 
 
-def get_repository_class(raw_repo):
+def get_repository_class(raw_configuration):
     """
+    Given a raw repository configuration, returns its corresponding class.
 
-    :param raw_repo:
-    :return:
-    :rtype: type
+    :param raw_configuration: configuration as returned by the SCRIPT_NAME_GET
+        groovy script.
+    :type raw_configuration: dict
+    :return: repository class
     """
-    class_name = raw_repo_to_class_name(raw_repo)
+    class_name = _repository_class_name(raw_configuration)
     for class_ in model.__all__:
         if class_.__name__ == class_name:
             return class_
-    raise NotImplementedError(f'{class_name} for {raw_repo}')
+    raise NotImplementedError(f'{class_name} for {raw_configuration}')
 
 
-def raw_repo_to_recipe(raw_repo):
-    recipe = raw_repo['format']
+def _recipe_name(raw_configuration):
+    """
+    Given a raw repository configuration, returns its recipe name.
 
-    if recipe == 'maven2':
-        return 'maven'
+    :param raw_configuration: configuration as returned by the SCRIPT_NAME_GET
+        groovy script.
+    :type raw_configuration: dict
+    :return: name of the recipe ("format")
+    """
+    name = raw_configuration['recipeName'].split('-')[0].title()
 
-    return recipe
+    if name == 'Maven2':
+        name = 'Maven'
+
+    return name
 
 
-def raw_repo_to_class_name(raw_repo):
-    recipe = raw_repo_to_recipe(raw_repo)
+def _recipe_type(raw_configuration):
+    """
+    Given a raw repository configuration, returns its recipe type.
+
+    :param raw_configuration: configuration as returned by the SCRIPT_NAME_GET
+        groovy script.
+    :type raw_configuration: dict
+    :return: Group, Proxy or Hosted
+    """
+    return raw_configuration['recipeName'].split('-')[1].title()
+
+
+def _repository_class_name(raw_configuration):
+    """
+    Given a raw repository configuration, returns the corresponding python
+    repository class name.
+
+    :param raw_configuration: configuration as returned by the SCRIPT_NAME_GET
+        groovy script.
+    :type raw_configuration: dict
+    :return: name of the repository class
+    """
+    recipe_name = _recipe_name(raw_configuration)
     class_name = ''
 
     # The Repository class is the default because it implements most of the
     # recipes
-    if recipe not in model.Repository.RECIPES:
-        class_name += recipe.title()
+    if recipe_name not in model.Repository.RECIPES:
+        class_name += recipe_name
 
-    class_name += raw_repo['type'].title()
+    class_name += _recipe_type(raw_configuration)
 
     class_name += 'Repository'
 
     return class_name
 
 
-def raw_repo_to_args_kwargs(raw_repo):
-    args = (raw_repo['name'],)
-    kwargs = {'recipe': raw_repo_to_recipe(raw_repo)}
+# TODO: flattening-out the configuration on the python class turned-out to be
+#   a bad idea because now we need to convert it back and forth. Perhaps add
+#   a compatible change that allows one to provide the flat kwargs OR a
+#   configuration dict in the format accepted/returned by Nexus.
+def _add_proxy_kwargs(kwargs, attributes):
+    kwargs['auto_block'] = attributes['httpclient']['autoBlock']
 
-    if raw_repo['type'] == 'proxy':
-        kwargs['remote_url'] = raw_repo['url']
+    kwargs['content_max_age'] = int(attributes['proxy']['contentMaxAge'])
+    kwargs['metadata_max_age'] = int(attributes['proxy']['metadataMaxAge'])
+    kwargs['remote_url'] = attributes['proxy']['remoteUrl']
+
+    kwargs['negative_cache_enabled'] = attributes['negativeCache']['enabled']
+    kwargs['negative_cache_ttl'] = int(
+        attributes['negativeCache']['timeToLive'])
+
+
+def _add_maven_kwargs(kwargs, attributes):
+    kwargs['layout_policy'] = attributes['maven']['layoutPolicy']
+    kwargs['version_policy'] = attributes['maven']['versionPolicy']
+
+
+def _add_yum_kwargs(kwargs, attributes):
+    kwargs['depth'] = int(attributes['yum']['repodataDepth'])
+    # TODO: support yum deploy policy
+    # kwargs['TODO'] = attributes['yum']['deployPolicy']
+
+
+def _add_hosted_kwargs(kwargs, attributes):
+    kwargs['write_policy'] = attributes['storage']['writePolicy']
+
+
+def _add_common_kwargs(kwargs, attributes):
+    kwargs['cleanup_policy'] = attributes.get('cleanup', {}).get('policyName')
+    if kwargs['cleanup_policy'] == 'None':
+        kwargs['cleanup_policy'] = None
+
+    kwargs['blob_store_name'] = attributes['storage']['blobStoreName']
+    kwargs['strict_content_type_validation'] = attributes[
+        'storage']['strictContentTypeValidation']
+
+
+def _repository_args_kwargs(raw_configuration):
+    args = (raw_configuration['repositoryName'],)
+    kwargs = {'recipe': _recipe_name(raw_configuration)}
+
+    attributes = raw_configuration['attributes']
+    _add_common_kwargs(kwargs, attributes)
+
+    if _recipe_name(raw_configuration) == 'Maven':
+        _add_maven_kwargs(kwargs, attributes)
+
+    if _recipe_name(raw_configuration) == 'Yum':
+        _add_yum_kwargs(kwargs, attributes)
+
+    # TODO: support Group
+    if _recipe_type(raw_configuration) == 'Proxy':
+        _add_proxy_kwargs(kwargs, attributes)
+
+    if _recipe_type(raw_configuration) == 'Hosted':
+        _add_hosted_kwargs(kwargs, attributes)
 
     return args, kwargs
 
@@ -80,18 +166,10 @@ class RepositoryCollection:
         :raise exception.NexusClientInvalidRepository: when a repository with
             the given name isn't found.
         """
-        try:
-            raw_repo = self.get_raw_by_name(name)
-        except IndexError:
-            raise exception.NexusClientInvalidRepository(name)
+        configuration = self.get_raw_by_name(name)
+        Repository = get_repository_class(configuration)
+        args, kwargs = _repository_args_kwargs(configuration)
 
-        Repository = get_repository_class(raw_repo)
-        # FIXME: use groovy to fetch a matching json object so the conversion
-        #   isn't required; this would also fix the issue below
-        args, kwargs = raw_repo_to_args_kwargs(raw_repo)
-
-        # FIXME: missing yum repo attributes
-        #   https://github.com/thiagofigueiro/nexus3-cli/issues/73
         return Repository(*args, nexus_client=self._client, **kwargs)
 
     def get_raw_by_name(self, name):
@@ -99,21 +177,21 @@ class RepositoryCollection:
         Return the raw dict for the repository called ``name``. Remember to
         :meth:`refresh` to get the latest from the server.
 
-        Args:
-            name (str): name of wanted repository
-
-        Returns:
-            dict: the repository, if found.
-
-        Raises:
-            :class:`IndexError`: if no repository named ``name`` is found.
-
+        :param name: name of the repository wanted
+        :type name: str
+        :rtype: dict
+        :raise exception.NexusClientInvalidRepository: when a repository with
+            the given name isn't found.
         """
-        for r in self._repositories_json:
-            if r['name'] == name:
-                return r
+        self._client.scripts.create_if_missing(SCRIPT_NAME_GET)
 
-        raise IndexError
+        resp = self._client.scripts.run(SCRIPT_NAME_GET, data=name)
+        configuration = resp.get('result')
+
+        if configuration == 'null':
+            raise exception.NexusClientInvalidRepository(name)
+
+        return json.loads(configuration)
 
     def refresh(self):
         """

--- a/src/nexuscli/api/repository/collection.py
+++ b/src/nexuscli/api/repository/collection.py
@@ -1,6 +1,6 @@
 import json
 
-from nexuscli import exception, nexus_util
+from nexuscli import exception
 from nexuscli.api.repository import model
 
 SCRIPT_NAME_CREATE = 'nexus3-cli-repository-create'
@@ -144,8 +144,7 @@ class RepositoryCollection:
         :param name: name of the repository to be deleted.
         :type name: str
         """
-        content = nexus_util.groovy_script(SCRIPT_NAME_DELETE)
-        self._client.scripts.create_if_missing(SCRIPT_NAME_DELETE, content)
+        self._client.scripts.create_if_missing(SCRIPT_NAME_DELETE)
         self._client.scripts.run(SCRIPT_NAME_DELETE, data=name)
 
     def create(self, repository):
@@ -161,8 +160,7 @@ class RepositoryCollection:
             raise TypeError(f'{repository} has type {type(repository)}'
                             f' but must be a subclass of Repository')
 
-        content = nexus_util.groovy_script(SCRIPT_NAME_CREATE)
-        self._client.scripts.create_if_missing(SCRIPT_NAME_CREATE, content)
+        self._client.scripts.create_if_missing(SCRIPT_NAME_CREATE)
 
         script_args = json.dumps(repository.configuration)
         resp = self._client.scripts.run(SCRIPT_NAME_CREATE, data=script_args)

--- a/src/nexuscli/api/repository/model.py
+++ b/src/nexuscli/api/repository/model.py
@@ -61,7 +61,7 @@ class Repository:
                  ):
         self.name = name
         self.nexus_client = nexus_client
-        self.recipe = recipe
+        self.recipe = recipe.lower()
         self.blob_store_name = blob_store_name
         self.strict_content = strict_content_type_validation
         self.cleanup_policy = cleanup_policy
@@ -453,8 +453,63 @@ class YumProxyRepository(ProxyRepository, YumRepository):
     pass
 
 
+# For the convenience of not having to handle these recipe names differently
+class BowerHostedRepository(HostedRepository):
+    pass
+
+
+class BowerProxyRepository(ProxyRepository):
+    pass
+
+
+class NpmHostedRepository(HostedRepository):
+    pass
+
+
+class NpmProxyRepository(ProxyRepository):
+    pass
+
+
+class NugetHostedRepository(HostedRepository):
+    pass
+
+
+class NugetProxyRepository(ProxyRepository):
+    pass
+
+
+class PypiHostedRepository(HostedRepository):
+    pass
+
+
+class PypiProxyRepository(ProxyRepository):
+    pass
+
+
+class RawHostedRepository(HostedRepository):
+    pass
+
+
+class RawProxyRepository(ProxyRepository):
+    pass
+
+
+class RubygemsHostedRepository(HostedRepository):
+    pass
+
+
+class RubygemsProxyRepository(ProxyRepository):
+    pass
+
+
 __all__ = [
     Repository, HostedRepository, ProxyRepository,
+    BowerHostedRepository, BowerProxyRepository,
     MavenHostedRepository, MavenProxyRepository,
+    NpmHostedRepository, NpmProxyRepository,
+    NugetHostedRepository, NugetProxyRepository,
+    PypiHostedRepository, PypiProxyRepository,
+    RawHostedRepository, RawProxyRepository,
+    RubygemsHostedRepository, RubygemsProxyRepository,
     YumHostedRepository, YumProxyRepository,
 ]

--- a/src/nexuscli/api/repository/model.py
+++ b/src/nexuscli/api/repository/model.py
@@ -61,6 +61,8 @@ class Repository:
                  ):
         self.name = name
         self.nexus_client = nexus_client
+        # TODO: remove this the RECIPES attributes; no longer needed as there's
+        #   a unique class for each recipe/type.
         self.recipe = recipe.lower()
         self.blob_store_name = blob_store_name
         self.strict_content = strict_content_type_validation

--- a/src/nexuscli/api/script/groovy/nexus3-cli-repository-get.groovy
+++ b/src/nexuscli/api/script/groovy/nexus3-cli-repository-get.groovy
@@ -1,0 +1,19 @@
+import groovy.json.JsonBuilder
+
+Boolean exists = repository.repositoryManager.get(args) as Boolean
+
+if (!exists)
+    return null
+
+repo_config = repository.repositoryManager.get(args).configuration
+
+def repositoryConfiguration = new JsonBuilder()
+repositoryConfiguration repo_config
+
+repositoryConfiguration  {
+    repositoryName repo_config.repositoryName
+    recipeName repo_config.recipeName
+    attributes repo_config.attributes
+}
+
+return repositoryConfiguration.toPrettyString()

--- a/src/nexuscli/api/script/model.py
+++ b/src/nexuscli/api/script/model.py
@@ -1,4 +1,4 @@
-from nexuscli import exception
+from nexuscli import exception, nexus_util
 
 
 class ScriptCollection(object):
@@ -69,14 +69,25 @@ class ScriptCollection(object):
 
         return resp.json()
 
-    def create_if_missing(self, name, content, script_type='groovy'):
+    def create_if_missing(self, name, content=None, script_type='groovy'):
         """
         Creates a script in the Nexus 3 service IFF a script with the same name
         doesn't exist. Equivalent to checking if the script exists with
         :meth:`get` and, if not, creating it with :meth:`create`.
 
-        Parameters as per :py:meth:`create`.
+        :param name: name of script to be created.
+        :type name: str
+        :param content: script code. If not given, the method will use
+            :py:meth:`nexuscli.nexus_util.groovy_script` to read the script
+            code from a local file.
+        :type content: Union[str,NoneType]
+        :param script_type: type of script to be created.
+        :type script_type: str
+        :raises exception.NexusClientAPIError: if the script creation isn't
+            successful; i.e.: any HTTP code other than 204.
         """
+        content = content or nexus_util.groovy_script(name)
+
         if not self.exists(name):
             self.create(name, content, script_type)
 

--- a/src/nexuscli/cli/errors.py
+++ b/src/nexuscli/cli/errors.py
@@ -8,4 +8,5 @@ class CliReturnCode(Enum):
     API_ERROR = 2
     INVALID_SUBCOMMAND = 10
     POLICY_NOT_FOUND = 20
+    REPOSITORY_NOT_FOUND = 30
     UNKNOWN_ERROR = 99

--- a/src/nexuscli/cli/subcommand_repository.py
+++ b/src/nexuscli/cli/subcommand_repository.py
@@ -106,7 +106,7 @@ def cmd_create(nexus_client, args):
             'layout_policy': args.get('--layout').upper()})
 
     Repository = repository.collection.get_repository_class({
-        'format': recipe_name, 'type': repo_type})
+        'recipeName': f'{recipe_name}-{repo_type}'})
 
     r = Repository(args.get('<repo_name>'), **kwargs)
 

--- a/src/nexuscli/nexus_client.py
+++ b/src/nexuscli/nexus_client.py
@@ -46,6 +46,8 @@ class NexusClient(object):
         :class:`~nexuscli.api.repository.collection.RepositoryCollection`. This
         will automatically use the existing instance of :class:`NexusClient` to
         communicate with the Nexus service.
+
+        :rtype: RepositoryCollection
         """
         if self._repositories is None:
             self._repositories = RepositoryCollection(client=self)

--- a/tests/api/repository/conftest.py
+++ b/tests/api/repository/conftest.py
@@ -1,3 +1,5 @@
+import json
+import pathlib
 import pytest
 
 from nexuscli.api import repository
@@ -30,3 +32,36 @@ def yum_repos():
     ]
     for yum_repo_class in yum_repos:
         yield yum_repo_class
+
+
+@pytest.helpers.register
+def default_repos():
+    default_repos_path = pathlib.Path('tests/fixtures/default-repos')
+
+    for config_file in default_repos_path.glob('*.json'):
+        with config_file.open() as fh:
+            config = json.load(fh)
+        yield pytest.param(config, id=config_file.name)
+
+
+@pytest.helpers.register
+def compare_dict(d1, d2):
+    """
+    Compares dictionaries. Shamelessly
+    borrowed from http://stackoverflow.com/a/18860653
+
+    :param d2: dictionary to compare this one against
+    :type d2: dict
+    :return: tuple of entries that were: added, removed, modified, equal
+    :rtype: tuple
+    """
+    self_keys = set(d1.keys())
+    d_keys = set(d2.keys())
+    intersect_keys = self_keys.intersection(d_keys)
+    added = self_keys - d_keys
+    removed = d_keys - self_keys
+    modified = {
+        o: (d1[o], d2[o]) for o in intersect_keys if d1[o] != d2[o]
+    }
+    same = set(o for o in intersect_keys if d1[o] == d2[o])
+    return added, removed, modified, same

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -9,4 +9,4 @@ def repo_name(basename, *args):
     name = basename
     for token in args:
         name += f'-{token}'
-    return f'{name}-{faker.random_number()}'
+    return f'{name}-{faker.pystr()}'

--- a/tests/cli/test_subcommand_repository.py
+++ b/tests/cli/test_subcommand_repository.py
@@ -78,8 +78,7 @@ def test_create_hosted_yum(nexus_client, w_policy, depth, strict, c_policy):
         '--depth={depth} {strict} --cleanup={c_policy}', **locals())
 
     assert pytest.helpers.create_and_inspect(nexus_client, argv, repo_name)
-    # FIXME: https://github.com/thiagofigueiro/nexus3-cli/issues/73
-    # assert nexus_client.repositories.get_by_name(repo_name).depth == depth
+    assert nexus_client.repositories.get_by_name(repo_name).depth == depth
 
 
 @pytest.mark.parametrize(

--- a/tests/fixtures/default-repos/maven-central.json
+++ b/tests/fixtures/default-repos/maven-central.json
@@ -1,0 +1,30 @@
+{
+  "repositoryName": "maven-central",
+  "recipeName": "maven2-proxy",
+  "attributes": {
+    "proxy": {
+      "contentMaxAge": -1,
+      "remoteUrl": "https://repo1.maven.org/maven2/",
+      "metadataMaxAge": 1440
+    },
+    "negativeCache": {
+      "timeToLive": 1440,
+      "enabled": true
+    },
+    "storage": {
+      "strictContentTypeValidation": false,
+      "blobStoreName": "default"
+    },
+    "maven-indexer": {},
+    "httpclient": {
+      "connection": {
+        "blocked": false,
+        "autoBlock": true
+      }
+    },
+    "maven": {
+      "versionPolicy": "RELEASE",
+      "layoutPolicy": "PERMISSIVE"
+    }
+  }
+}

--- a/tests/fixtures/default-repos/maven-public.json
+++ b/tests/fixtures/default-repos/maven-public.json
@@ -1,0 +1,19 @@
+{
+  "repositoryName": "maven-public",
+  "recipeName": "maven2-group",
+  "attributes": {
+    "maven": {
+      "versionPolicy": "MIXED"
+    },
+    "group": {
+      "memberNames": [
+        "maven-releases",
+        "maven-snapshots",
+        "maven-central"
+      ]
+    },
+    "storage": {
+      "blobStoreName": "default"
+    }
+  }
+}

--- a/tests/fixtures/default-repos/maven-releases.json
+++ b/tests/fixtures/default-repos/maven-releases.json
@@ -1,0 +1,15 @@
+{
+  "repositoryName": "maven-releases",
+  "recipeName": "maven2-hosted",
+  "attributes": {
+    "maven": {
+      "versionPolicy": "RELEASE",
+      "layoutPolicy": "STRICT"
+    },
+    "storage": {
+      "writePolicy": "ALLOW_ONCE",
+      "strictContentTypeValidation": false,
+      "blobStoreName": "default"
+    }
+  }
+}

--- a/tests/fixtures/default-repos/maven-snapshots.json
+++ b/tests/fixtures/default-repos/maven-snapshots.json
@@ -1,0 +1,15 @@
+{
+  "repositoryName": "maven-snapshots",
+  "recipeName": "maven2-hosted",
+  "attributes": {
+    "maven": {
+      "versionPolicy": "SNAPSHOT",
+      "layoutPolicy": "STRICT"
+    },
+    "storage": {
+      "writePolicy": "ALLOW",
+      "strictContentTypeValidation": false,
+      "blobStoreName": "default"
+    }
+  }
+}


### PR DESCRIPTION
1. Use a groovy script instead of the REST API to get a repository
2. Create classes for all supported repository recipes/types
3. Enable yum depth test
4. Use nexus repository configuration when creating a python repository instance from an existing repo
5. New `nexus3 repository show` command