### PR TITLE
py.path causes problems when packaging nexus-cli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import io
 from setuptools import find_packages, setup
 
 package_name = 'nexus3-cli'
-package_version = '2.1.0'
+package_version = '2.1.1'
 
 requires = [
     'clint',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ requires = [
     'future',
     'faker',
     'inflect',
-    'py',
     'future',
     'requests[security]>=2.14.2',
     'six',

--- a/src/nexuscli/nexus_client.py
+++ b/src/nexuscli/nexus_client.py
@@ -421,6 +421,27 @@ class NexusClient(object):
 
         return upload_count
 
+    @staticmethod
+    def _ensure(local_absolute_path):
+        """
+        Create all dirs on the path and the file.
+        """
+        if local_absolute_path.find('//') != -1:
+            sep = '//'
+        elif local_absolute_path.find('\\\\') != -1:
+            sep = '\\\\'
+        elif local_absolute_path.find('\\') != -1:
+            sep = '\\'
+        else:
+            sep = '/'
+
+        parts = local_absolute_path.split(sep)
+        dirs = sep.join(parts[:-1])
+
+        os.makedirs(dirs)
+        with open(local_absolute_path, 'w') as _file:
+            _file.write('')
+
     def _remote_path_to_local(
             self, remote_src, local_dst, flatten, create=True):
         """
@@ -463,11 +484,11 @@ class NexusClient(object):
                 local_relative = os.path.join(
                     local_relative_dir, dst_file_name)
 
-        destination_path = py.path.local(local_dst)
-        local_absolute_path = destination_path.join(local_relative)
+        local_absolute_path = local_dst + local_relative
 
         if create:
-            local_absolute_path.ensure(dir=remote_isdir)
+            if not os.path.exists(local_absolute_path):
+                self._ensure(local_absolute_path)
         return str(local_absolute_path)
 
     @staticmethod

--- a/src/nexuscli/nexus_client.py
+++ b/src/nexuscli/nexus_client.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os.path
-import py
 import requests
 import sys
 from clint.textui import progress
@@ -428,7 +427,7 @@ class NexusClient(object):
         parts = local_absolute_path.split(self._local_sep)
         dirs = self._local_sep.join(parts[:-1])
 
-        os.makedirs(dirs)
+        os.makedirs(dirs, exist_ok=True)
         with open(local_absolute_path, 'w') as _file:
             _file.write('')
 

--- a/src/nexuscli/nexus_client.py
+++ b/src/nexuscli/nexus_client.py
@@ -421,22 +421,12 @@ class NexusClient(object):
 
         return upload_count
 
-    @staticmethod
-    def _ensure(local_absolute_path):
+    def _ensure(self, local_absolute_path):
         """
         Create all dirs on the path and the file.
         """
-        if local_absolute_path.find('//') != -1:
-            sep = '//'
-        elif local_absolute_path.find('\\\\') != -1:
-            sep = '\\\\'
-        elif local_absolute_path.find('\\') != -1:
-            sep = '\\'
-        else:
-            sep = '/'
-
-        parts = local_absolute_path.split(sep)
-        dirs = sep.join(parts[:-1])
+        parts = local_absolute_path.split(self._local_sep)
+        dirs = self._local_sep.join(parts[:-1])
 
         os.makedirs(dirs)
         with open(local_absolute_path, 'w') as _file:


### PR DESCRIPTION
I had a project that uses nexus-cli and i package this project using pyinstaller to delivery it for the users. But the nexus_cli.download uses py.path to ensure that all dirs and files on the local_absolute_path were created. 
The problem is that py.path imports at runtime it's dependencies and it causes a problem when the project was packaged (Exception ModuleNotFoundError: No module named 'py._path')
To avoid this situation i change the code to use only os.makerdirs and write the file. This prevents the need of using py.path.
I know that could be a way to force pyinstaller to include all py dependeces but i think that not good for nexus3-cli lib to have this "hidden" depences.