### PR TITLE
Take Nexus context into account in REST calls

### DIFF
--- a/src/nexuscli/nexus_client.py
+++ b/src/nexuscli/nexus_client.py
@@ -117,7 +117,10 @@ class NexusClient(object):
 
         :rtype: str
         """
-        url = urljoin(self.config.url, '/service/rest/')
+        baseurl = self.config.url
+        if not self.config.url.endswith('/'):
+            baseurl += '/'
+        url = urljoin(baseurl, 'service/rest/')
         return urljoin(url, self.config.api_version + '/')
 
     def http_request(self, method, endpoint, service_url=None, **kwargs):

--- a/src/nexuscli/nexus_client.py
+++ b/src/nexuscli/nexus_client.py
@@ -117,10 +117,7 @@ class NexusClient(object):
 
         :rtype: str
         """
-        baseurl = self.config.url
-        if not self.config.url.endswith('/'):
-            baseurl += '/'
-        url = urljoin(baseurl, 'service/rest/')
+        url = urljoin(self.config.url, 'service/rest/')
         return urljoin(url, self.config.api_version + '/')
 
     def http_request(self, method, endpoint, service_url=None, **kwargs):

--- a/src/nexuscli/nexus_config.py
+++ b/src/nexuscli/nexus_config.py
@@ -43,6 +43,8 @@ class NexusConfig:
         self._username = username
         self._password = password
         self._url = url
+        if not self._url.endswith('/'):
+            self._url += '/'
         self._x509_verify = x509_verify
         self._config_path = Path(config_path or DEFAULT_CONFIG)
 

--- a/tests/test_nexus_client.py
+++ b/tests/test_nexus_client.py
@@ -83,6 +83,6 @@ def test_nexus_context_path(url, expected_base, mocker):
 
     NexusClient(NexusConfig(url=url))
     requests.request.assert_called_once_with(
-        auth=('admin', 'admin123'), method='get', stream=True,
+        auth=(nexus_config.DEFAULTS['username'], nexus_config.DEFAULTS['password']), method='get', stream=True,
         url=(expected_base + 'service/rest/v1/repositories'),
         verify=True)

--- a/tests/test_nexus_client.py
+++ b/tests/test_nexus_client.py
@@ -5,6 +5,7 @@ import requests
 import nexuscli
 from nexuscli import exception
 from nexuscli.nexus_client import NexusClient, NexusConfig
+from nexuscli.nexus_config import DEFAULTS
 
 
 def test_repositories(mocker):
@@ -83,6 +84,6 @@ def test_nexus_context_path(url, expected_base, mocker):
 
     NexusClient(NexusConfig(url=url))
     requests.request.assert_called_once_with(
-        auth=(nexus_config.DEFAULTS['username'], nexus_config.DEFAULTS['password']), method='get', stream=True,
-        url=(expected_base + 'service/rest/v1/repositories'),
+        auth=(DEFAULTS['username'], DEFAULTS['password']), method='get',
+        stream=True, url=(expected_base + 'service/rest/v1/repositories'),
         verify=True)

--- a/tests/test_nexus_client.py
+++ b/tests/test_nexus_client.py
@@ -4,8 +4,8 @@ import requests
 
 import nexuscli
 from nexuscli import exception
-from nexuscli.nexus_client import NexusClient, NexusConfig
-from nexuscli.nexus_config import DEFAULTS
+from nexuscli.nexus_client import NexusClient
+from nexuscli.nexus_config import DEFAULTS, NexusConfig
 
 
 def test_repositories(mocker):


### PR DESCRIPTION
`urljoin(self.config.url, '/service/rest/')` discards the path component of `self.config.url` since the leading `/` on the second argument indicates it's an absolute URL: https://stackoverflow.com/questions/10893374/python-confusions-with-urljoin

This should fix it. Includes mock tests.