### PR TITLE
Fix CleanupPolicy API doc: days not seconds

### DIFF
--- a/src/nexuscli/api/cleanup_policy/model.py
+++ b/src/nexuscli/api/cleanup_policy/model.py
@@ -16,9 +16,9 @@ class CleanupPolicy(object):
         mode (str): 'delete'
         criteria (dict): the deletion criteria for the policy. Supports one or
             more of the following attributes:
-                - ``lastDownloaded`` (int): seconds since artefact last
+                - ``lastDownloaded`` (int): days since artefact last
                   downloaded;
-                - ``lastBlobUpdated`` (int): seconds since last update to
+                - ``lastBlobUpdated`` (int): days since last update to
                   artefact;
     """
     def __init__(self, client, **kwargs):


### PR DESCRIPTION
Nexus takes seconds but nexus3-cli takes days and converts it in the groovy script.