### PR TITLE
Samuelrohr raise exception on http request error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import io
 from setuptools import find_packages, setup
 
 package_name = 'nexus3-cli'
-package_version = '2.1.2'
+package_version = '2.1.3'
 
 requires = [
     'clint',

--- a/src/nexuscli/cli/errors.py
+++ b/src/nexuscli/cli/errors.py
@@ -6,6 +6,7 @@ class CliReturnCode(Enum):
     SUCCESS = 0
     NO_FILES = 1
     API_ERROR = 2
+    CONNECTION_ERROR = 3
     INVALID_SUBCOMMAND = 10
     POLICY_NOT_FOUND = 20
     REPOSITORY_NOT_FOUND = 30

--- a/src/nexuscli/cli/subcommand_repository.py
+++ b/src/nexuscli/cli/subcommand_repository.py
@@ -151,4 +151,10 @@ def main(argv=None):
     """Entrypoint for ``nexus3 repository`` subcommand."""
     arguments = docopt(__doc__, argv=argv)
     command_method = util.find_cmd_method(arguments, globals())
-    return command_method(util.get_client(), arguments)
+
+    # TODO: generic implementation in src/nexuscli/cli/__init__.py
+    try:
+        return command_method(util.get_client(), arguments)
+    except exception.NexusClientConnectionError as e:
+        print(f'Connection error: {e}')
+        return errors.CliReturnCode.CONNECTION_ERROR.value

--- a/src/nexuscli/exception.py
+++ b/src/nexuscli/exception.py
@@ -3,6 +3,11 @@ class NexusClientAPIError(Exception):
     pass
 
 
+class NexusClientConnectionError(Exception):
+    """Generic network connector error."""
+    pass
+
+
 class NexusClientInvalidCredentials(Exception):
     """
     Login credentials not accepted by Nexus service. Usually the result of a

--- a/src/nexuscli/nexus_client.py
+++ b/src/nexuscli/nexus_client.py
@@ -143,7 +143,7 @@ class NexusClient(object):
                 method=method, auth=self.config.auth, url=url,
                 verify=self.config.x509_verify, **kwargs)
         except requests.exceptions.ConnectionError as e:
-            raise exception.NexusClientConnectionError(str(e))
+            raise exception.NexusClientConnectionError(str(e)) from None
 
         if response.status_code == 401:
             raise exception.NexusClientInvalidCredentials(

--- a/src/nexuscli/nexus_client.py
+++ b/src/nexuscli/nexus_client.py
@@ -143,8 +143,7 @@ class NexusClient(object):
                 method=method, auth=self.config.auth, url=url,
                 verify=self.config.x509_verify, **kwargs)
         except requests.exceptions.ConnectionError as e:
-            print(e)
-            sys.exit(1)
+            raise exception.NexusClientConnectionError(str(e))
 
         if response.status_code == 401:
             raise exception.NexusClientInvalidCredentials(


### PR DESCRIPTION
Quick-and-dirty to avoid a breaking-change. To be refactored later:

1. move exception handling from `subcommand_repository` to `__init__`
2. use custom exception to hold CliReturnCode

Fixes https://github.com/thiagofigueiro/nexus3-cli/issues/85