### PR TITLE
cha: Upload error will have more info printed

### DIFF
--- a/src/nexuscli/api/repository/upload.py
+++ b/src/nexuscli/api/repository/upload.py
@@ -33,7 +33,8 @@ def upload_file_raw(repository, src_file, dst_dir, dst_file):
 
     if response.status_code != 204:
         raise exception.NexusClientAPIError(
-            f'Uploading to {repository.name}. Reason: {response.reason}')
+            f'Uploading to {repository.name}. Reason: {response.reason} '
+            f'Status code: {response.status_code} Text: {response.text}')
 
 
 def upload_file_yum(repository, src_file, dst_dir, dst_file):
@@ -58,4 +59,5 @@ def upload_file_yum(repository, src_file, dst_dir, dst_file):
 
     if response.status_code != 200:
         raise exception.NexusClientAPIError(
-            f'Uploading to {repository_path}. Reason: {response.reason}')
+            f'Uploading to {repository_path}. Reason: {response.reason} '
+            f'Status code: {response.status_code} Text: {response.text}')


### PR DESCRIPTION
When upload fails for any reason related to the repo configuration or file type mismatch,
nexus3 will tell nothing more than "Server Error".
This patch makes it more descriptive about what happened.