### PR TITLE
Fix subcommand help

### DIFF
--- a/src/nexuscli/cli/__init__.py
+++ b/src/nexuscli/cli/__init__.py
@@ -88,7 +88,15 @@ def _run_subcommand(arguments, subcommand):
         print(__doc__)
         sys.exit(errors.CliReturnCode.INVALID_SUBCOMMAND.value)
 
-    return subcommand_method(argv)
+    try:
+        return subcommand_method(argv)
+    except DocoptExit:
+        # Show help for the subcommand. The exception instance also has the
+        # the help but we can't use it because it won't have the `-h` details.
+        # This is because `-h` is handled by the first call to docopt, in main.
+        # FIXME: docopt is now more work than it's worth it
+        print(subcommand_module.__doc__)
+        return exception.CliReturnCode.SUBCOMMAND_ERROR.value
 
 
 def main(argv=None):

--- a/src/nexuscli/cli/subcommand_cleanup_policy.py
+++ b/src/nexuscli/cli/subcommand_cleanup_policy.py
@@ -1,12 +1,10 @@
 """
 Usage:
-  nexus3 cleanup_policy --help
   nexus3 cleanup_policy create <policy_name> [--format=<format>]
          [--downloaded=<days>] [--updated=<days>]
   nexus3 cleanup_policy list
 
 Options:
-  -h --help             This screen
   --format=<format>     Accepted: all or a repository format [default: all]
   --downloaded=<days>   Cleanup criteria; last downloaded in this many days.
   --updated=<days>      Cleanup criteria; last updated in this many days.

--- a/src/nexuscli/cli/subcommand_repository.py
+++ b/src/nexuscli/cli/subcommand_repository.py
@@ -1,6 +1,5 @@
 """
 Usage:
-  nexus3 repository --help
   nexus3 repository list
   nexus3 repository show <repo_name>
   nexus3 repository (delete|del) <repo_name> [--force]
@@ -49,8 +48,7 @@ Usage:
          [--https_port=<https_port>]
 
 Options:
-  -h --help                             This screen  # noqa: E501
-  --blob=<store_name>                   Use this blob with new repository  [default: default]
+  --blob=<store_name>                   Use this blob with new repository  [default: default]  # noqa: E501
   --depth=<repo_depth>                  Depth (0-5) where repodata folder(s) exist [default: 0]
   --layout=<l_policy>                   Accepted: strict, permissive [default: strict]
   --strict-content                      Enable strict content type validation

--- a/src/nexuscli/cli/subcommand_script.py
+++ b/src/nexuscli/cli/subcommand_script.py
@@ -1,13 +1,11 @@
 """
 Usage:
-  nexus3 script --help
   nexus3 script create <script_name> <script_path> [--script_type=<type>]
   nexus3 script list
   nexus3 script run <script_name> [<script_args>]
   nexus3 script (delete|del) <script_name>
 
 Options:
-  -h --help             This screen
   --script_type=<type>  Script type [default: groovy]
 
 Commands:


### PR DESCRIPTION
Fix #97 partially.

Still a bit of a hack as we now assume `-h` any time there's an error in a subcommand. I didn't want to spend more time than needed on this since the plan is to refactor the CLI to remove docopt.